### PR TITLE
Add comments. Change question for Entrance rotation determination.

### DIFF
--- a/Pathos-Nethack-Helper/LostChambers/PortalData.cs
+++ b/Pathos-Nethack-Helper/LostChambers/PortalData.cs
@@ -106,8 +106,8 @@ namespace Pathos_Nethack_Helper.LostChambers
                 // The entrance room has four fake walls. Two have mindflayers, and two have open/empty chests.
                 // The Mindflayers are accross from each other, and the chests are across from each other.
                 // The chest on one wall is centered, and the other is offset. This relative orientation is consistent.
-                "Of the four fake walls, two of them have empty chests. In which direction is the centered chest?",
-                new string[]{"North", "East", "South", "West"});
+                "Of the four fake walls, in which direction is the centered chest hidden?",
+                new string[]{"East", "South", "West", "North"});
             _rotationQuestions.Add(entranceQuestion.RoomForQuestion, entranceQuestion);
             
             RotationQuestion waterQuestion = new RotationQuestion(LostChamber.RoomName.Water,

--- a/Pathos-Nethack-Helper/LostChambers/PortalData.cs
+++ b/Pathos-Nethack-Helper/LostChambers/PortalData.cs
@@ -99,6 +99,12 @@ namespace Pathos_Nethack_Helper.LostChambers
             return results;
         }
 
+        /*
+         * The rotation questions are based on the original map. The rotation is clockwise, so the first
+         * value in the string array indicates a 0 degrees rotation, the second is 90 degrees, etc. The
+         * questions are based on the original map data recorded manually. The first answer is the value
+         * matching that rotation data. The other answers represent a rotation of that "default" case.
+         */
         private void InitRotationQuestions()
         {
             _rotationQuestions = new Dictionary<LostChamber.RoomName, RotationQuestion>();

--- a/Pathos-Nethack-Helper/LostChambers/PortalData.cs
+++ b/Pathos-Nethack-Helper/LostChambers/PortalData.cs
@@ -103,11 +103,15 @@ namespace Pathos_Nethack_Helper.LostChambers
         {
             _rotationQuestions = new Dictionary<LostChamber.RoomName, RotationQuestion>();
             RotationQuestion entranceQuestion = new RotationQuestion(LostChamber.RoomName.Entrance, 
-                "Of the three fake walls, in which direction is the mind flayer hidden?",
+                // The entrance room has four fake walls. Two have mindflayers, and two have open/empty chests.
+                // The Mindflayers are accross from each other, and the chests are across from each other.
+                // The chest on one wall is centered, and the other is offset. This relative orientation is consistent.
+                "Of the four fake walls, two of them have empty chests. In which direction is the centered chest?",
                 new string[]{"North", "East", "South", "West"});
             _rotationQuestions.Add(entranceQuestion.RoomForQuestion, entranceQuestion);
             
             RotationQuestion waterQuestion = new RotationQuestion(LostChamber.RoomName.Water,
+                // The water room has a single fountain out of sight from the entrance portal and centered on one wall.
                 "Which direction is the fountain?",
                 new string[]{"West", "North", "East", "South"});
             _rotationQuestions.Add(waterQuestion.RoomForQuestion, waterQuestion);


### PR DESCRIPTION
I added two comments describing the room a bit more, and I changed the Entrance rotation question from using the mind flayer(s) to using the chests. The chests have been constant in every run I've looked at them (a sample size of about 4), but I think I've seen variants of spawning either one or two mind flayers. The last three runs had two mind flayers.